### PR TITLE
docs: complete documentation refactor with namespaces and breadcrumbs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,11 @@ repository:
   - [`SECURITY.md`](./.github/SECURITY.md): A template for the user's
     security policy.
 
-- **[`docs/`](./docs/)**: Contains all documentation for the project.
-  Each major feature or component has its own corresponding `.md` file in this
-  directory.
+- **[`docs/`](./docs/)**: Contains all documentation for the project. The documentation is organized into a dual-TOC, namespaced structure.
+  - **`docs/README.md`**: The main entry point and master Table of Contents, linking to all published documentation files.
+  - **`docs/<namespace>.md`**: A scoped Table of Contents for a specific namespace, providing an overview and links to all sub-pages in that namespace.
+  - **`docs/<namespace>.<topic>.md`**: An individual documentation page.
+  - **`docs/in-dev.<topic>.md`**: An in-development document that is excluded from all TOCs.
 
 - **[`docker/`](./docker/)**: Contains the development environment.
   - [`Dockerfile`](./docker/Dockerfile): Builds a generic Ubuntu + NGINX
@@ -88,7 +90,15 @@ repository:
 - **Update Documentation:** If you change a feature, you **must** update its
   corresponding documentation in the [`docs/`](./docs/) directory.
   If you add a new feature, you **must** create a new documentation file for
-  it.
+  it, following the namespace and dual-TOC structure. This means:
+  1.  Identify the correct namespace for your documentation (e.g., `development`, `workflows`).
+  2.  Create a new file named `docs/<namespace>.<your-topic>.md`.
+  3.  Add a link to your new file in **two** places:
+      - The main Table of Contents in `docs/README.md`, under the appropriate namespace heading.
+      - The namespace-specific index file, `docs/<namespace>.md`.
+  4.  If you are creating a new namespace, you must also create a `docs/<namespace>.md` index file and link to it from the main `docs/README.md`.
+  5.  **In-Development Documents:** For documentation that is in-development or not ready for general viewing, place it in the `in-dev` namespace (e.g., `docs/in-dev.my-draft.md`). Files in this namespace are automatically excluded from all Tables of Contents.
+  6.  **Add Breadcrumbs:** The first line of every new documentation file must be a clickable breadcrumb trail. Refer to existing documentation files for the correct format and relative link structure.
 - **Verify Your Work:** After creating or modifying a file, use a read-only
   tool like `read_file` or `ls` to confirm your changes were applied
   correctly before marking a step as complete.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,26 +1,16 @@
+[base](../README.md) > docs
+
 # Documentation
 
 This directory contains the documentation for the `base` project.
 
 - [The `base` Philosophy](./base.md) - An overview of the core principles and goals of this template.
-- [Documentation Index](./README.md) - You are here.
 
-## AI
+[Guides](#guides) - [Development](#development) - [CI/CD](#cicd-workflows) - [Publishing](#publishing-your-project) - [Updating](#updating) - [Project Management](#project-management) - [Community](#community) - [AI](#ai) - [Documentation](#documentation-best-practices)
 
-- [Guiding AI with `AGENTS.md`](./ai.agents-md.md) - Using `AGENTS.md` to provide instructions to AI agents.
-- [Prompting AI Agents](./ai.prompting.md) - How to effectively prompt AI agents.
+## Guides
 
-## CI/CD
-
-- [Secrets Management](./workflows.secrets-management.md) - Best practices for managing secrets in GitHub Actions.
-- [Workflow Scheduling](./workflows.scheduling.md) - Automating recurring tasks with cron.
-- [GitHub Workflows](./workflows.md) - Explanation of the CI/CD workflows.
-
-## Community
-
-- [Community Building Guide](./community.building.md) - Fostering a healthy and effective community.
-- [Using GitHub Discussions](./community.discussions.md) - Leveraging Discussions for community conversations.
-- [Issue Management Guide](./community.issue-management.md) - Best practices for triaging issues.
+- [Software Project Guide](./guides.software-project.md) - Using this repo as a foundation for a software project.
 
 ## Development
 
@@ -28,15 +18,22 @@ This directory contains the documentation for the `base` project.
 - [Docker Environment](./development.docker.md) - Using the included Docker setup.
 - [`package.json` Guide](./development.package-json.md) - Explanation of the `package.json` files.
 - [Using Prettier](./development.prettier.md) - Guide to installing and using Prettier.
-- [Prettier Workflow](./development.prettier-workflow.md) - Manually formatting code.
 
-## Documentation
+## CI/CD Workflows
 
-- [Documentation Best Practices](./documentation.best-practices.md) - How to write clear and effective documentation.
+- [**CI Workflow**](./workflows.ci.md) (`ci.yml`) - Ensures code quality by running linting checks on every push and pull request to the `main` branch.
+- [**GitHub Pages Deployment**](./workflows.pages.md) (`pages.yml`) - Builds and deploys the repository's content as a GitHub Pages website.
+- [**Prettier Workflow**](./workflows.prettier.md) (`prettier.yml`) - Automatically formats the code in the repository using Prettier and commits the changes.
+- [**Release on Tag**](./workflows.release-on-tag.md) (`release-on-tag.yml`) - Automates the creation of GitHub Releases when a new version tag is pushed.
+- [**Secrets Management**](./workflows.secrets-management.md) - Best practices for managing secrets in GitHub Actions.
+- [**Workflow Scheduling**](./workflows.scheduling.md) - Automating recurring tasks with cron.
 
-## Guides
+## Publishing Your Project
 
-- [Software Project Guide](./guides.software-project.md) - Using this repo as a foundation for a software project.
+- [Publishing with Markdown](./publishing.markdown.md) - The simplest way to get started.
+- [Advanced Publishing with HTML](./publishing.html.md) - For those who need more control over their site's layout and appearance.
+- [Publishing with Magic Links](./publishing.magic-links.md) - A powerful feature for community-driven sites.
+- [GitHub Pages](./publishing.github-pages.md) - More detail on how the underlying GitHub Pages service works.
 
 ## Updating
 
@@ -53,10 +50,18 @@ This directory contains the documentation for the `base` project.
 - [Template Repo Guide](./project.template-repo.md) - Best practices for maintaining this template.
 - [Versioning Guide](./project.versioning.md) - Professional release management.
 
-## Publishing
+## Community
 
-- [Publishing Overview](./publishing.md) - An overview of the different ways to publish content.
-- [Publishing with Markdown](./publishing.markdown.md) - The simplest way to create pages.
-- [Advanced Publishing with HTML](./publishing.html.md) - For more control over layout and style.
-- [Publishing with Magic Links](./publishing.magic-links.md) - Creating links that pre-fill new file content.
-- [GitHub Pages](./publishing.github-pages.md) - How the underlying publishing system works.
+- [Community Building Guide](./community.building.md) - Fostering a healthy and effective community.
+- [Using GitHub Discussions](./community.discussions.md) - Leveraging Discussions for community conversations.
+- [Issue Management Guide](./community.issue-management.md) - Best practices for triaging issues.
+- [Community Wiki](./community.wiki.md) - A community-maintained wiki.
+
+## AI
+
+- [Guiding AI with `AGENTS.md`](./ai.agents-md.md) - Using `AGENTS.md` to provide instructions to AI agents.
+- [Prompting AI Agents](./ai.prompting.md) - How to effectively prompt AI agents.
+
+## Documentation Best Practices
+
+- [Documentation Best Practices](./documentation.best-practices.md) - How to write clear and effective documentation.

--- a/docs/ai.agents-md.md
+++ b/docs/ai.agents-md.md
@@ -1,48 +1,72 @@
+[base](../../README.md) > [docs](../README.md) > [ai](./ai.md) > Guiding AI with AGENTS.md
+
 # Guiding AI with `AGENTS.md`
 
-The `AGENTS.md` file is a special document within this repository designed to
-be a direct line of communication between you (the user) and any AI agent or
-assistant working on your project.
-Think of it as a set of permanent instructions or a "cheat sheet" for the AI.
+The `AGENTS.md` file is a crucial tool for ensuring that AI assistants, like
+Jules, can effectively and safely interact with your repository.
+It acts as a repository-specific instruction manual, allowing you to define
+conventions, outline procedures, and provide context that the AI needs to
+perform its tasks correctly.
 
-## What is its Purpose?
+This guide explains the purpose and best practices for creating and maintaining
+an `AGENTS.md` file.
 
-While you can give an AI instructions in a prompt, those instructions are
-temporary and specific to that one conversation.
-The `AGENTS.md` file provides a persistent set of rules and guidelines that
-the AI can refer to at any time.
+## Why Use `AGENTS.md`?
 
-This is particularly useful for establishing:
+1.  **Contextual Awareness:** An AI assistant, even with general knowledge,
+    lacks the specific context of your project.
+    `AGENTS.md` bridges this gap by providing essential information about your
+    repository's architecture, coding conventions, and development workflows.
 
-- **Coding Standards:** "Always use tabs, not spaces."
-- **Architectural Rules:** "All new components must be registered in the main
-  application file."
-- **Testing Requirements:** "Every new function must be accompanied by a unit
-  test."
-- **Repository-Specific Information:** "The `api/` directory is
-  auto-generated, do not edit it directly."
+2.  **Enforcing Conventions:** You can specify rules that the AI must follow,
+    such as commit message formats, branching strategies, or code styling
+    guidelines.
+    This ensures that the AI's contributions are consistent with your project's
+    standards.
 
-## How to Use and Modify It
+3.  **Improving Accuracy:** By providing clear instructions, you reduce the
+    likelihood of the AI making incorrect assumptions.
+    This leads to more accurate and reliable results, saving you time on rework
+    and corrections.
 
-The `AGENTS.md` file is written in simple Markdown.
-You can edit it just like any other text file.
+4.  **Safe Automation:** You can define "do's and don'ts" to prevent the AI
+    from taking unintended or destructive actions, such as force-pushing to a
+    branch or modifying critical configuration files without explicit
+    permission.
 
-### Best Practices
+## How it Works
 
-1.  **Be Clear and Direct:** Write instructions as if you are speaking
-    directly to the AI.
-    Use clear, unambiguous language.
-2.  **Use Markdown for Structure:** Use headings, bullet points, and code
-    blocks to keep the document organized and easy for the AI to parse.
-3.  **Keep It Updated:** As your project evolves, so should your `AGENTS.md`
-    file.
-    If you change your architecture or coding standards, update the file to
-    reflect those changes.
-4.  **Reference It in Your Prompts:** For best results, remind the AI to look
-    for and follow the instructions in your `AGENTS.md` file as part of your
-    initial prompt.
-    The `prompting-ai-agents.md` guide provides examples of how to do this.
+-   **Location:** The `AGENTS.md` file can be placed in the root of your
+    repository or in any subdirectory.
+-   **Scope:** The instructions in an `AGENTS.md` file apply to all files and
+    directories within the directory that contains it, and all of its
+    subdirectories.
+-   **Precedence:** If there are multiple `AGENTS.md` files (e.g., one in the
+    root and one in a subdirectory), the instructions in the more deeply nested
+    file take precedence for the files within its scope.
 
-By maintaining a well-structured `AGENTS.md` file, you can significantly
-improve the quality and consistency of the work done by AI agents on your
-project, reducing the need for corrections and rework.
+## What to Include in `AGENTS.md`
+
+Here are some common types of information to include in your `AGENTS.md` file:
+
+-   **Project Overview:** A brief description of the project's purpose and
+    technology stack.
+-   **Repository Structure:** An explanation of the key directories and their
+    contents.
+-   **Development Workflow:** Step-by-step instructions for setting up the
+    development environment, running tests, and building the project.
+-   **Coding Conventions:** Guidelines for code style, naming conventions, and
+    best practices.
+-   **Commit Message Format:** The preferred format for commit messages (e.g.,
+    Conventional Commits).
+-   **Branching Strategy:** The branching model used in the repository (e.g.,
+    GitFlow, GitHub Flow).
+-   **Release Process:** Instructions for creating and publishing new releases.
+-   **Specific Instructions for AI:** Any unique rules or constraints that apply
+    only to AI assistants.
+
+By investing a small amount of time in creating a comprehensive `AGENTS.md`
+file, you can significantly improve the effectiveness and reliability of AI
+collaboration on your project.
+It's a powerful way to guide the AI toward producing high-quality, consistent,
+and safe contributions.

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -1,0 +1,8 @@
+[base](../README.md) > [docs](./README.md) > ai
+
+# AI
+
+This section contains documentation related to Artificial Intelligence.
+
+- [Guiding AI with `AGENTS.md`](./ai.agents-md.md) - Using `AGENTS.md` to provide instructions to AI agents.
+- [Prompting AI Agents](./ai.prompting.md) - How to effectively prompt AI agents.

--- a/docs/ai.prompting.md
+++ b/docs/ai.prompting.md
@@ -1,87 +1,92 @@
-# Prompting AI Agents for `attogram/base` Projects
+[base](../../README.md) > [docs](../README.md) > [ai](./ai.md) > Prompting AI Agents
 
-When using AI agents to create or update a repository based on
-`attogram/base`, providing a clear, upfront context is the most effective way
-to get the results you want.
-This guide provides two distinct prompt examples to help you steer AI agents in
-the right direction, whether you want to build upon the `base` philosophy or
-intentionally modify it.
+# Prompting AI Agents
 
----
+Effective prompting is the key to getting high-quality results from AI
+assistants like Jules.
+A well-crafted prompt provides the necessary context, constraints, and goals,
+enabling the AI to understand your request and execute it accurately.
 
-## Prompt 1: Using `base` As-Is
+This guide provides best practices and examples for writing effective prompts.
 
-This prompt is ideal when you want to create a new project that adheres to the
-core, language-agnostic philosophy of the `attogram/base` template.
+## Principles of Good Prompting
 
-### Example Prompt: Create a Personal Blog
+1.  **Be Specific and Clear:** Avoid ambiguity.
+    Clearly state what you want the AI to do, what files to modify, and what
+    the expected outcome is.
+    -   **Bad:** "Fix the bug."
+    -   **Good:** "Fix the bug in `src/utils.js` where the `calculateTotal`
+        function is off by one.
+        It should correctly sum the items in the array."
 
-```
-This project builds upon the attogram/base template.
-Please integrate the new website content without removing the core base
-repository files or structure.
+2.  **Provide Context:** Give the AI the information it needs to understand the
+    task.
+    This can include:
+    -   Relevant file paths.
+    -   Error messages or logs.
+    -   The business goal or user story behind the change.
+    -   Links to relevant documentation or examples.
 
-The main homepage for the site is `README.md`, and all new content should be
-linked from there.
-You can create new directories for your content as needed, but please do not
-modify the core `base` files and directories (such as `.github`, `docs`,
-`docker`, etc.).
+3.  **Set Constraints:** Tell the AI what it should *not* do.
+    -   "Do not modify the public API."
+    -   "Do not install any new dependencies."
+    -   "Ensure the solution is compatible with Python 3.8."
 
-Please use the existing Jekyll setup for the site, which builds from the root
-directory.
-Do not install other static site generators like Eleventy.
+4.  **Define the Scope:** Clearly define the boundaries of the task.
+    -   "This task only involves changes to the `docs/` directory."
+    -   "Focus only on refactoring the `UserService`, do not change the
+        `OrderService`."
 
-Finally, please look for and follow any instructions in an `AGENTS.md` file,
-as it may contain project-specific guidelines for AI agents.
-```
+5.  **Reference `AGENTS.md`:** If your repository has an `AGENTS.md` file,
+    remind the AI to read and follow its instructions.
+    -   "Please make sure you have read and understood the guidelines in
+        `AGENTS.md` before starting."
 
----
+## Example Prompts
 
-## Prompt 2: Modifying `base` for a New Technology
+### Example 1: Fixing a Bug
 
-This prompt is for when you want to use `attogram/base` as a starting point
-but intend to introduce a specific programming language or framework.
-This example uses PHP and Laravel.
+**Prompt:**
 
-### Example Prompt: Add a Laravel Backend
+> "Jules, there is a bug in our `api/views.py` file.
+> When a user's subscription is inactive, the `/api/profile` endpoint is
+> throwing a 500 error instead of a 403 Forbidden error.
+>
+> Please fix the logic in the `get_profile` view to correctly handle this case.
+>
+> **Acceptance Criteria:**
+> -   If the user's `subscription.is_active` is `False`, the endpoint must
+>     return a 403 status code.
+> -   The change should only affect the `api/views.py` file.
+> -   Please add a unit test in `tests/test_api.py` to cover this specific
+>     case.
+>
+> Remember to follow the coding standards outlined in `AGENTS.md`."
 
-```
-This project will use `attogram/base` as a foundation, but we will be
-modifying it to support a PHP/Laravel application.
+### Example 2: Adding a New Feature
 
-Here are the requirements:
-1.  **Add PHP and Laravel:** Please modify the Docker environment to include
-    PHP and the necessary extensions for a Laravel application.
-2.  **Install Laravel:** Once the environment is updated, install a fresh copy
-    of the Laravel framework in a `/src` directory at the repository root.
-3.  **Update NGINX:** Configure the NGINX server to point to the `public`
-    directory of the Laravel application.
-4.  **Preserve Core Files:** Do not remove the existing GitHub Actions
-    workflows or the documentation in the `/docs` directory.
-    The goal is to integrate Laravel into the `base` template, not replace it.
-5.  **Check for `AGENTS.md`:** Please look for and follow any instructions in
-    an `AGENTS.md` file, as it may contain project-specific guidelines for AI
-    agents.
-```
+**Prompt:**
 
----
+> "I need to add a new feature to our application.
+> We need a new API endpoint at `/api/users/{id}/export` that exports a user's
+> data as a CSV file.
+>
+> **Requirements:**
+> 1.  Create a new function in `services/user_service.py` called
+>     `export_user_data(user_id)`.
+>     This function should query the database for the user's profile
+>     information.
+> 2.  Create a new view in `api/views.py` that handles the `/api/users/{id}/export`
+>     endpoint.
+>     It should call the `export_user_data` service and return the data as a
+>     CSV file with the appropriate `Content-Disposition` header.
+> 3.  The CSV should contain the following columns: `user_id`, `email`,
+>     `first_name`, `last_name`, `join_date`.
+>
+> Do not add any new dependencies.
+> This is a new feature, so please create a new documentation page for it at
+> `docs/api.user-export.md`."
 
-## Why These Prompts Work
-
-Providing a detailed, upfront prompt like the examples above is crucial for
-several reasons:
-
-- **Sets Clear Expectations:** The AI immediately understands the scope of the
-  project.
-  It knows whether to preserve the `base` philosophy or to modify it, which is
-  the most critical distinction.
-- **Reduces Errors and Rework:** By specifying the technology stack (or lack
-  thereof) and the desired file structure, you prevent the AI from making
-  incorrect assumptions that would need to be corrected later.
-- **Empowers the AI:** A clear prompt gives the AI the constraints it needs to
-  be creative and effective.
-  It can focus on the "how" because you've already defined the "what" and
-  "why."
-- **Faster, Better Results:** Ultimately, a few minutes spent crafting a
-  detailed prompt will save you hours of back-and-forth, leading to a better
-  final product that meets your requirements from the start.
+By following these principles, you can write prompts that are clear,
+context-rich, and actionable, leading to better and more predictable results
+from your AI assistant.

--- a/docs/base.md
+++ b/docs/base.md
@@ -1,36 +1,59 @@
+[base](../README.md) > [docs](./README.md) > base
+
 # The `base` Philosophy
 
-Welcome to `base`.
-This repository is designed to be a robust, professional, and
-[well-documented](./README.md) starting point for new software and publishing
-projects.
+The `base` project is a language-agnostic, professional template for creating
+new software projects. It is designed to be a solid foundation that you can
+build upon, regardless of the programming language or framework you choose.
 
 ## Core Principles
 
-The development of this template is guided by a few core principles:
+1.  **Code-Independent:** The `base` template itself is not tied to any
+    specific programming language. The included Docker environment is based on
+    Ubuntu and NGINX to be as generic as possible. This allows you to bring your
+    own language and tools without having to untangle a complex, pre-existing
+    stack.
 
-1.  **Code-Independent:** The template should not be tied to a specific
-    programming language.
-    The goal is to provide a solid foundation of repository structure, CI/CD,
-    and best practices that can be adapted to any language or framework.
+2.  **Well-Documented:** Every feature, configuration file, and workflow has
+    corresponding documentation in this `docs` directory. The goal is to leave
+    no part of the repository unexplained, making it easy for new contributors
+    to get up to speed and for maintainers to understand all the components.
 
-2.  **Well-Documented:** Every component, workflow, and configuration file is
-    documented in the [`docs`](./) directory.
-    The goal is to make the repository easy to understand and modify.
-    See the [documentation index](./README.md) for a complete list of
-    documents.
+3.  **Guidance over Prescription:** For standard files like `CONTRIBUTING.md` or
+    `LICENSE`, the template provides sensible defaults and guides you on how to
+    customize them, rather than enforcing a single choice. This empowers you to
+    make decisions that are right for your project while still benefiting from
+    a professional starting point.
 
-3.  **Guidance Over Prescription:** The template provides sensible defaults and
-    placeholder files that guide the user on how to create their own
-    project-specific content, such as contributing guidelines or a license.
-
-4.  **Automation:** The template includes automated workflows for common tasks
-    like linting, testing, and creating releases, helping to ensure code
-    quality and streamline the development process.
+4.  **Automation:** The repository leverages GitHub Actions for CI, deployment,
+    and releases to automate common developer tasks. These workflows are
+    designed to be robust and easy to understand, providing a solid CI/CD
+    pipeline out of the box.
 
 ## How to Use This Repository
 
-This repository is intended to be used as a
-[GitHub Template](https://docs.github.com/en/repositories/creating-a-repository-on-github/creating-a-repository-from-a-template).
-Click the "Use this template" button at the top of the repository page to
-create your own new repository with the same structure and files.
+There are two primary ways to use this repository as a starting point for your
+own project:
+
+1.  **As a Template:** The simplest method is to click the "Use this template"
+    button at the top of the repository page on GitHub. This will create a new
+    repository in your account with the same files and directory structure, but
+    without the commit history. This is the recommended approach for new
+-   projects.
+-   [**Adding `base` to an Existing Repo**](./updating.adding-base-to-existing-repo.md)
+-   [**Syncing When `base` is Updated**](./updating.syncing-your-repo-when-base-is-updated.md)
++   projects. See the guides on
++   [adding `base` to an existing repo](./updating.adding-base-to-existing-repo.md)
++   and
++   [syncing when `base` is updated](./updating.syncing-your-repo-when-base-is-updated.md)
++   for more advanced use cases.
+
+2.  **As a Fork:** You can also fork this repository. This creates a copy of the
+    repository in your account that maintains a connection to the original. This
+    is useful if you want to contribute changes back to the `base` project
+    itself, or if you want to be able to easily pull in updates from the original
+    repository.
+
+By providing a clean, well-documented, and automated starting point, the `base`
+project aims to save you time and effort, allowing you to focus on what matters
+most: building your application.

--- a/docs/community.building.md
+++ b/docs/community.building.md
@@ -1,72 +1,83 @@
+[base](../../README.md) > [docs](../README.md) > [community](./community.md) > Community Building Guide
+
 # Community Building Guide
 
-A thriving open-source project is built on a foundation of a healthy,
-welcoming, and effective community.
-Here are some best practices for fostering such an environment.
+Building a healthy and effective community around your open source project is
+just as important as writing good code.
+A strong community can help with everything from finding bugs and adding new
+features to supporting new users and promoting your project.
 
-## 1. Establish a Code of Conduct
+This guide provides best practices for fostering a positive and productive
+community environment.
 
-A [Code of Conduct](../CODE_OF_CONDUCT.md) is a document that outlines the
-expected standards of behavior for all community members.
-It's a clear statement that your project is a safe and inclusive space.
-
-- **Adopt a Standard:** You don't have to write one from scratch.
-  The [Contributor Covenant](https://www.contributor-covenant.org/) is a
-  widely used and respected choice.
-  This repository includes a template to get you started.
-- **Enforce It:** A Code of Conduct is only effective if it's enforced.
-  Be prepared to act on reports of violations to protect your community.
-
-## 2. Be Welcoming and Responsive
+## 1. Create a Welcoming Environment
 
 First impressions matter.
-How you treat newcomers will determine whether they stick around.
+Newcomers should feel that their contributions are welcome and valued,
+regardless of their skill level.
 
-- **Welcome Contributions:** Use a `CONTRIBUTING.md` file to explain how
-  people can contribute.
-  Thank contributors for their work, even if you don't merge it.
-- **Be Responsive:** Respond to issues and pull requests in a timely manner.
-  If you're busy, a quick "Thanks for the report, I'll look into this next
-  week" is better than silence.
+-   **Code of Conduct:** Adopt and enforce a
+    [Code of Conduct](./CODE_OF_CONDUCT.md).
+    This sets the tone for respectful and inclusive interactions.
+-   **Contribution Guidelines:** Provide a clear
+    [`CONTRIBUTING.md`](./CONTRIBUTING.md) file that explains how to get
+    involved, from reporting bugs to submitting pull requests.
+-   **Be Responsive:** Acknowledge new issues and pull requests promptly, even
+    if it's just to say "thanks for the contribution, I'll review this soon."
+-   **Celebrate Contributions:** Publicly thank contributors for their work.
+    Consider using a tool like the
+    [All Contributors](https://allcontributors.org/) bot to recognize all
+    types of contributions, not just code.
 
-## 3. Provide Clear Communication Channels
+## 2. Provide Clear and Accessible Documentation
 
-Designate specific places for different types of community interaction.
-
-- **GitHub Issues:** Use issues for actionable tasks like bug reports and
-  feature requests.
-  This repository's [issue templates](./.github/ISSUE_TEMPLATE/) help
-  structure this process.
-- **GitHub Discussions:** Enable
-  [GitHub Discussions](https://docs.github.com/en/discussions) for open-ended
-  conversations, Q&A, and sharing ideas.
-  This keeps your issue tracker focused.
-- **Other Channels:** Consider a chat platform like Slack or Discord for more
-  informal community interaction, but be mindful of the moderation overhead.
-
-## 4. Document Everything
-
-Good documentation is a cornerstone of a healthy community.
+Good documentation is the foundation of a healthy community.
 It empowers users to solve their own problems and lowers the barrier to
 contribution.
 
-- **User Guides:** Write clear, concise guides for using your project.
-- **Reference Material:** Provide detailed documentation for APIs,
-  configuration options, and other technical aspects.
-- **Contribution Guidelines:** Your `CONTRIBUTING.md` should clearly explain
-  how to set up a development environment, run tests, and submit changes.
+-   **README:** Your main `README.md` should be a clear and concise entry
+    point to your project.
+-   **Getting Started Guide:** Provide a step-by-step guide for setting up the
+    development environment and running the project for the first time.
+-   **API Reference:** If your project has an API, provide a comprehensive
+    reference that is easy to navigate.
+-   **Keep it Updated:** Ensure your documentation stays in sync with your
+    codebase.
+    Outdated documentation can be a major source of frustration for your
+    community.
 
-## 5. Empower Your Community
+## 3. Establish Clear Communication Channels
 
-As your community grows, look for opportunities to empower trusted members.
+Provide clear and accessible channels for your community to ask questions,
+share ideas, and collaborate.
 
-- **Recognize Contributors:** Acknowledge valuable contributions publicly.
-  This could be through release notes, social media shout-outs, or a
-  contributors list in your README.
-- **Delegate Responsibility:** Invite experienced community members to help
-  triage issues, review pull requests, or moderate discussion channels.
+-   **GitHub Issues:** Use GitHub Issues for bug reports and feature requests.
+-   **GitHub Discussions:** For more open-ended conversations, questions, and
+    community announcements, enable
+    [GitHub Discussions](./community.discussions.md).
+-   **Other Channels:** Depending on your community's preferences, you might
+    also consider a chat platform like Discord or Slack.
+    Whatever you choose, make it clear where users should go for different
+    types of communication.
 
-Building a community takes time and effort, but it's one of the most
-rewarding aspects of maintaining an open-source project.
-By being intentional about creating a positive and productive environment, you
-can build a project that lasts.
+## 4. Be a Good Steward
+
+As a maintainer, your role is to guide the project and its community.
+
+-   **Set a Vision:** Have a clear vision for the future of the project and
+    communicate it to your community.
+    A public roadmap can be a great way to do this.
+-   **Be Open to Feedback:** Be willing to listen to your community's ideas and
+    concerns, even if you don't always agree.
+-   **Delegate:** As your community grows, you won't be able to do everything
+    yourself.
+    Empower trusted community members to help with tasks like triaging issues,
+    reviewing pull requests, and moderating discussions.
+-   **Lead by Example:** The tone and behavior of the maintainers will set the
+    standard for the entire community.
+    Be patient, respectful, and appreciative.
+
+Building a community takes time and effort, but it's one of the most rewarding
+aspects of running an open source project.
+By creating a welcoming, well-documented, and communicative environment, you can
+foster a community that will help your project thrive for years to come.

--- a/docs/community.discussions.md
+++ b/docs/community.discussions.md
@@ -1,72 +1,78 @@
+[base](../../README.md) > [docs](../README.md) > [community](./community.md) > Using GitHub Discussions
+
 # Using GitHub Discussions
 
-GitHub Discussions is a feature designed to be the community forum for your
-project, right alongside your code.
-It provides a dedicated space for conversations, Q&A, and idea sharing,
-keeping your issue tracker clean and focused on actionable tasks.
+GitHub Discussions is a powerful tool for building a community around your
+project.
+It provides a dedicated space for conversations that don't fit neatly into the
+structured format of GitHub Issues.
+Think of it as a forum or a message board that lives right alongside your code.
 
-## Issues vs. Discussions: What's the Difference?
+This guide explains how to enable and effectively use GitHub Discussions.
 
-Understanding when to use Issues and when to use Discussions is key to
-keeping your project organized.
+## Enabling Discussions
 
-- **GitHub Issues** are for tracking specific, actionable tasks.
-  They have a clear "done" state.
-  - **Use for:** Bug reports, feature requests with a clear scope, specific
-    to-do items.
-  - **Example:** "The login button is broken on Safari."
+To enable Discussions for your repository:
 
-- **GitHub Discussions** are for open-ended conversations.
-  They don't have a "done" state and are about exploration and communication.
-  - **Use for:** Q&A, sharing ideas, general feedback, showing off what you've
-    built.
-  - **Example:** "What do you think about adding a dark mode?" or "How do I
-    connect the app to a different database?"
+1.  Navigate to your repository's main page on GitHub.
+2.  Click on the **Settings** tab.
+3.  Scroll down to the "Features" section.
+4.  Check the box next to **Discussions**.
 
-By directing non-actionable conversations to Discussions, you prevent your
-issue tracker from becoming cluttered with questions and long debates,
-allowing you to focus on the work that needs to be done.
+It may take a few moments, but a new "Discussions" tab will appear in your
+repository's navigation bar.
 
-## How to Enable and Use Discussions
+## When to Use Discussions vs. Issues
 
-1.  **Enable Discussions:** In your repository settings, under the "Features"
-    section, check the box for "Discussions."
+It's important to guide your community on when to use Discussions and when to
+use Issues.
+Here's a common breakdown:
 
-2.  **Configure Categories:** Set up categories to organize your community's
-    conversations.
-    Good starting categories include:
-    - **Announcements:** For maintainers to share project news.
-    - **Q&A:** For users to ask questions.
-      This category has a feature to mark an answer as correct.
-    - **Ideas:** For proposing and debating new features.
-    - **Show and Tell:** For community members to share what they've built
-      with your project.
+**Use GitHub Issues for:**
 
-See:
-[Managing categories for discussions](https://docs.github.com/en/discussions/managing-discussions-for-your-community/managing-categories-for-discussions)
+-   **Bug Reports:** Actionable reports of problems with your code.
+-   **Feature Requests:** Specific requests for new functionality.
+-   **Tasks:** Any item that has a clear "done" state.
 
-## Best Practices for Maintainers
+**Use GitHub Discussions for:**
 
-1.  **Seed the Conversation:** When you first enable Discussions, post a
-    welcome message or an announcement to get things started.
+-   **Q&A:** Questions about how to use your project.
+-   **Ideas:** Open-ended brainstorming and suggestions for new features.
+-   **Show and Tell:** A place for community members to share what they've
+    built with your project.
+-   **Announcements:** A place for maintainers to share news and updates.
 
-2.  **Be Active:** Participate in discussions, answer questions, and encourage
-    community members.
-    Your engagement sets the tone.
+You can create categories in your Discussions to help organize these different
+types of conversations.
 
-3.  **Moderate as Needed:** As with any community forum, be prepared to
-    moderate to ensure conversations remain respectful and productive, in line
-    with your [Code of Conduct](./CODE_OF_CONDUCT.md).
+## Best Practices for Managing Discussions
 
-4.  **Convert Issues to Discussions:** If a user opens an issue that is
-    actually a question or a broad idea, you can convert it to a discussion.
-    This moves the conversation to the right place while preserving the
-    content.
+1.  **Seed Content:** When you first enable Discussions, it will be empty.
+    Create a few posts to get the conversation started.
+    You could post a "Welcome" message, an announcement, or a question to your
+    community.
 
-5.  **Convert Discussions to Issues:** Conversely, if a discussion evolves
-    into a concrete, actionable task (like a well-defined feature request),
-    you can create an issue directly from the discussion to track the work.
+2.  **Promote It:** Let your community know that Discussions is the place to
+    be.
+    Link to it from your `README.md` and `CONTRIBUTING.md` files.
+    If someone opens an issue that is better suited for a discussion, politely
+    guide them to the correct place and, if possible, convert the issue to a
+    discussion.
 
-By embracing GitHub Discussions, you can foster a vibrant community, gather
-valuable feedback, and maintain a clean, organized workflow for managing your
-project's development.
+3.  **Mark Answers:** In Q&A categories, you can mark a comment as the
+    accepted answer.
+    This helps other users with the same question quickly find the solution.
+    Encourage your community to help with this.
+
+4.  **Moderate:** As with any online community, moderation is key.
+    Ensure that conversations are respectful and stay on topic.
+    Make sure your [Code of Conduct](./CODE_OF_CONDUCT.md) is visible and
+    enforced.
+
+5.  **Engage:** Be an active participant in your community's discussions.
+    Answer questions, provide feedback on ideas, and celebrate what your users
+    are creating.
+
+By providing a dedicated and well-managed space for conversation, GitHub
+Discussions can help you build a more engaged, supportive, and collaborative
+community.

--- a/docs/community.issue-management.md
+++ b/docs/community.issue-management.md
@@ -1,95 +1,84 @@
+[base](../../README.md) > [docs](../README.md) > [community](./community.md) > Issue Management Guide
+
 # Issue Management Guide
 
-Effective issue management is key to keeping your project organized and your
-community engaged.
-This guide covers best practices for using GitHub Issues, labels, and
-templates to triage bug reports and feature requests.
+Effective issue management is crucial for a well-run open source project.
+A clean and organized issue tracker makes it easier for maintainers to
+prioritize work and for contributors to find ways to help.
+
+This guide provides best practices for triaging and managing issues in your
+repository.
 
 ## 1. Use Issue Templates
 
-The first step to effective issue management is to get clear, structured
-information from contributors.
-GitHub's issue templates are perfect for this.
+Good issues start with good information.
+[Issue templates](./.github/ISSUE_TEMPLATE/) prompt users to provide the
+necessary details when they open an issue, such as:
 
-- **What they are:** Pre-populated templates for bug reports and feature
-  requests that prompt the user for specific information.
-- **Why they're useful:** They ensure you get the information you need to act
-  on an issue, such as steps to reproduce a bug or the use case for a new
-  feature.
-- **How to use them:** This repository includes templates in the
-  [`.github/ISSUE_TEMPLATE/`](../.github/ISSUE_TEMPLATE/) directory.
-  You can customize them to fit your project's needs.
+-   Steps to reproduce the bug.
+-   The expected behavior vs. the actual behavior.
+-   The user's operating system and software versions.
+-   A clear description of the proposed feature.
 
-## 2. Leverage Labels
+This repository includes templates for bug reports and feature requests.
+Encourage your community to use them.
 
-Labels are a powerful tool for categorizing and prioritizing issues.
-A good set of labels makes it easy to see the state of your project at a
-glance.
+## 2. Label Your Issues
 
-### Recommended Label Categories
+Labels are a powerful tool for organizing your issue tracker.
+A good set of labels can help you quickly filter and prioritize issues.
 
-- **Issue Type:**
-  - `bug`: A problem with the existing code.
-  - `feature-request`: A proposal for new functionality.
-  - `documentation`: An issue related to the docs.
-  - `maintenance`: Chores like refactoring or updating dependencies.
+Consider creating labels for:
 
-- **Status:**
-  - `needs-triage`: A new issue that hasn't been reviewed yet.
-  - `confirmed`: A bug report that has been reproduced.
-  - `in-progress`: An issue that is actively being worked on.
-  - `blocked`: An issue that cannot be worked on due to external factors.
+-   **Issue Type:** `bug`, `feature`, `documentation`, `question`
+-   **Priority:** `high-priority`, `medium-priority`, `low-priority`
+-   **Status:** `needs-triage`, `help-wanted`, `good-first-issue`, `in-progress`,
+    `blocked`
+-   **Component:** `api`, `ui`, `database`, `tests`
 
-- **Priority:**
-  - `critical`: Must be addressed immediately (e.g., a security
-    vulnerability).
-  - `high`: Important and should be prioritized.
-  - `medium`: A standard issue.
-  - `low`: A non-urgent issue or nice-to-have feature.
+The `good-first-issue` label is particularly important for attracting new
+contributors.
+Use it to mark issues that are well-defined and don't require deep knowledge
+of the codebase.
 
-- **Contribution Welcome:**
-  - `good-first-issue`: A relatively simple issue that's a great entry point
-    for new contributors.
-  - `help-wanted`: An issue that you'd like the community to help with.
-
-## 3. The Triage Workflow
+## 3. Triage Regularly
 
 Triage is the process of reviewing new issues and preparing them for work.
-A typical workflow looks like this:
+Set aside time to regularly triage incoming issues.
 
-1.  **Review New Issues:** Regularly check for issues that don't have any
-    labels or assignees.
+A typical triage workflow might look like this:
 
-2.  **Ensure Clarity:** If an issue is unclear, ask the author for more
-    information.
+1.  **Read the issue:** Make sure you understand the problem or request.
+2.  **Check for duplicates:** If the issue is a duplicate, close it and link
+    to the original.
+3.  **Ask for more information:** If the issue is unclear or missing details,
+    ask the author to provide more information.
     If they don't respond after a reasonable amount of time, it's okay to
     close the issue.
+4.  **Reproduce bugs:** For bug reports, try to reproduce the issue yourself.
+    If you can't, ask for more help from the author.
+5.  **Apply labels:** Add the appropriate labels for type, priority, and
+    status.
 
-3.  **Reproduce Bugs:** For bug reports, try to reproduce the issue based on
-    the information provided.
-    If you can reproduce it, add a `confirmed` label.
-    If not, ask for more details.
+## 4. Prune Stale Issues
 
-4.  **Apply Labels:** Add the appropriate `type`, `status`, and `priority`
-    labels to the issue.
+It's okay to close issues that are no longer relevant or that you don't plan
+to address.
+A cluttered issue tracker can be intimidating for new contributors and can make
+it hard to see what's important.
 
-5.  **Engage with the Community:**
-    - For valid feature requests, discuss the proposal with the community to
-      gauge interest and gather ideas.
-    - For issues you won't address, explain why and close the issue
-      respectfully.
-    - For issues that are good for new contributors, add a `good-first-issue`
-      label and perhaps a comment with pointers on how to get started.
+Consider using a stale bot (like GitHub's built-in
+[stale action](https://github.com/actions/stale)) to automatically comment on
+and close issues that have been inactive for a long period.
 
-## 4. Use Milestones and Projects
+## 5. Guide Users to Discussions
 
-- **Milestones:** Group issues together for a specific release (e.g.,
-  `v1.1.0`).
-  This helps you track progress towards your next version.
-- **GitHub Projects:** For more complex work, use a project board to visualize
-  and manage the workflow of issues and pull requests, similar to a Kanban
-  board.
+Not every post in your issue tracker needs to be an issue.
+If a user opens an issue that is a question or a broad, open-ended idea,
+politely guide them to use
+[GitHub Discussions](./community.discussions.md) instead.
+This keeps your issue tracker focused on actionable tasks.
 
-By implementing these practices, you can create a clear, organized, and
-efficient issue management process that will benefit both you and your
-contributors.
+By following these best practices, you can maintain a clean, organized, and
+effective issue tracker that serves as the central hub for your project's
+development.

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,10 @@
+[base](../README.md) > [docs](./README.md) > community
+
+# Community
+
+This section contains documentation related to community management.
+
+- [Community Building Guide](./community.building.md) - Fostering a healthy and effective community.
+- [Using GitHub Discussions](./community.discussions.md) - Leveraging Discussions for community conversations.
+- [Issue Management Guide](./community.issue-management.md) - Best practices for triaging issues.
+- [Community Wiki](./community.wiki.md) - A community-maintained wiki.

--- a/docs/community.wiki.md
+++ b/docs/community.wiki.md
@@ -1,66 +1,66 @@
-# Using the GitHub Wiki
+[base](../../README.md) > [docs](../README.md) > [community](./community.md) > Community Wiki
 
-The GitHub Wiki is a powerful tool for hosting detailed, long-form documentation
-for your project.
-Unlike your repository's `README.md` file, which is meant to be a quick
-introduction, the wiki provides a dedicated space for comprehensive guides,
-tutorials, and reference material.
+# Community Wiki
 
-## `README.md` vs. Wiki: What's the Difference?
+A community wiki is a powerful tool for collaborative documentation.
+It allows any member of your community to contribute their knowledge, creating a
+rich, living resource that evolves over time.
 
-Understanding when to use your `README.md` and when to use the wiki is key to
-keeping your project's documentation organized and accessible.
+This guide explains how to leverage the repository itself to create a simple
+and effective community-managed wiki.
 
-- **`README.md`** is the front door to your project.
-  It should be concise and provide a high-level overview, installation
-  instructions, and a quick start guide.
-  It's the first thing most visitors will see.
+## How it Works
 
-- **The Wiki** is the library for your project.
-  It's the place for "deep dive" content that doesn't fit in the README.
-  - **Use for:** In-depth tutorials, API references, design documents, project
-    history, and FAQs.
-  - **Example:** A detailed guide on "Advanced Configuration Options" or a
-    "Contributor's Guide to the Codebase."
+Instead of using a separate system, this approach uses the `docs/` directory of
+your repository as the wiki.
+This has several advantages:
 
-By moving detailed documentation to the wiki, you keep your `README.md` clean
-and focused, while providing a structured and searchable home for your
-project's knowledge base.
+-   **No Extra Tools:** Everything is managed through the standard GitHub
+    workflow (pull requests, reviews, etc.).
+-   **Version Controlled:** All changes to the wiki are tracked in your Git
+    history.
+-   **Community-Driven:** Anyone can contribute by submitting a pull request.
 
-## How to Use the Wiki
+## Setting Up Your Wiki
 
-1.  **Enable the Wiki:** In your repository settings, under the "Features"
-    section, check the box for "Wiki."
+1.  **Create a Namespace:** As we've done here, you can create a `community.wiki`
+    file to serve as the main entry point for your wiki.
+    This keeps the wiki content organized within its own namespace.
 
-2.  **Create a Home Page:** Every wiki starts with a `Home.md` page.
-    This page should serve as a table of contents, with links to all the other
-    pages in your wiki.
+2.  **Add an Index:** Your main `community.wiki.md` file should act as an index,
+    linking to all the individual wiki pages.
 
-3.  **Add and Edit Pages:** You can add new pages and edit existing ones
-    directly in the GitHub web interface.
-    The wiki uses Markdown, just like the rest of GitHub.
+3.  **Encourage Contributions:** In your `CONTRIBUTING.md` and community
+    channels, let people know that the wiki is open for contributions.
 
-4.  **Link Pages Together:** Create links between your wiki pages to build a
-    cohesive and navigable documentation site.
-    You can link to another wiki page using the syntax `[[Page Name]]`.
+## Example Wiki Structure
 
-## Best Practices for Maintainers
+Your wiki could be organized with a structure like this:
 
-1.  **Keep it Organized:** Use the `Home.md` page as a table of contents.
-    Group related pages together with clear and consistent naming.
+```
+docs/
+├── community.wiki.md         # The main wiki index page
+├── community.wiki.faq.md     # A Frequently Asked Questions page
+├── community.wiki.glossary.md  # A glossary of terms
+└── community.wiki.tutorials/ # A directory for community-submitted tutorials
+    ├── ...
+    └── ...
+```
 
-2.  **Encourage Contributions:** By default, anyone with push access to your
-    repository can edit the wiki.
-    Encourage your community to contribute to the documentation.
+## Contribution Workflow
 
-3.  **Review and Curate:** Periodically review the content of your wiki to
-    ensure it is up-to-date and accurate.
-    Remove outdated information and refactor pages as your project evolves.
+Here's how a community member would add a new page to the wiki:
 
-4.  **Link to the Wiki from your `README.md`:** Add a link to your wiki from
-    your project's `README.md` file so that visitors can easily find your
-    detailed documentation.
+1.  **Fork the repository.**
+2.  **Create a new file** in the `docs/` directory, following the
+    `community.wiki.<topic>.md` naming convention.
+3.  **Write the content** for their new wiki page.
+4.  **Add a link** to their new page in the `docs/community.wiki.md` index file.
+5.  **Submit a pull request** with their changes.
 
-By leveraging the GitHub Wiki, you can build a comprehensive and collaborative
-documentation site that will help your users and contributors get the most out
-of your project.
+Maintainers can then review the contribution, suggest changes, and merge it
+into the project.
+
+By using your own repository as a wiki, you create a low-friction way for your
+community to share their knowledge, building a valuable and lasting resource for
+everyone.

--- a/docs/development.codespaces.md
+++ b/docs/development.codespaces.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [development](./development.md) > GitHub Codespaces
+
 # GitHub Codespaces
 
 This repository is configured to use

--- a/docs/development.docker.md
+++ b/docs/development.docker.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [development](./development.md) > Docker Environment
+
 # Docker-based Development Environment
 
 This repository includes a Docker-based development environment to ensure a

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,10 @@
+[base](../README.md) > [docs](./README.md) > development
+
+# Development
+
+This section contains documentation related to development practices and environment setup.
+
+- [GitHub Codespaces](./development.codespaces.md) - Using Codespaces for cloud-based development.
+- [Docker Environment](./development.docker.md) - Using the included Docker setup.
+- [`package.json` Guide](./development.package-json.md) - Explanation of the `package.json` files.
+- [Using Prettier](./development.prettier.md) - Guide to installing and using Prettier.

--- a/docs/development.package-json.md
+++ b/docs/development.package-json.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [development](./development.md) > package.json Guide
+
 # `package.json` and `package-lock.json`
 
 You may notice `package.json` and `package-lock.json` files in the root of

--- a/docs/development.prettier.md
+++ b/docs/development.prettier.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [development](./development.md) > Using Prettier
+
 # Prettier for Code Formatting
 
 [Prettier](https://prettier.io/) is an opinionated code formatter that enforces a consistent code style across the entire project. This repository is configured to use Prettier in two ways: automatically via a GitHub workflow and manually for local development.

--- a/docs/documentation.best-practices.md
+++ b/docs/documentation.best-practices.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [documentation](./documentation.md) > Documentation Best Practices
+
 # Documentation Best Practices
 
 Good documentation is one of the most important aspects of a successful

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,0 +1,7 @@
+[base](../README.md) > [docs](./README.md) > documentation
+
+# Documentation Best Practices
+
+This section contains documentation about writing documentation.
+
+- [Documentation Best Practices](./documentation.best-practices.md) - How to write clear and effective documentation.

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -1,0 +1,7 @@
+[base](../README.md) > [docs](./README.md) > guides
+
+# Guides
+
+This section contains guides for using this project.
+
+- [Software Project Guide](./guides.software-project.md) - Using this repo as a foundation for a software project.

--- a/docs/guides.software-project.md
+++ b/docs/guides.software-project.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [guides](./guides.md) > Software Project Guide
+
 # Use Case: A Starting Point for Your Software Project
 
 This repository is designed to be a robust foundation for a wide variety of

--- a/docs/in-dev.render.md
+++ b/docs/in-dev.render.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > in-dev > Render Deployment
+
 # Deploying to Render.com
 
 > [!WARNING]

--- a/docs/project.badges.md
+++ b/docs/project.badges.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [project](./project.md) > Repository Badges
+
 # Badges
 
 Badges are a common way to display the status of your project in your

--- a/docs/project.launch-checklist.md
+++ b/docs/project.launch-checklist.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [project](./project.md) > Launch Checklist
+
 # Project Launch Checklist
 
 Launching a new open-source project can be a daunting task.

--- a/docs/project.licensing.md
+++ b/docs/project.licensing.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [project](./project.md) > Licensing Info
+
 # Licensing Information
 
 This repository is distributed under the MIT License, the full text of which

--- a/docs/project.md
+++ b/docs/project.md
@@ -1,0 +1,13 @@
+[base](../README.md) > [docs](./README.md) > project
+
+# Project Management
+
+This section contains documentation related to project management.
+
+- [Repository Badges](./project.badges.md) - How to use and create repository badges.
+- [Launch Checklist](./project.launch-checklist.md) - A reusable checklist for project launches.
+- [Licensing Info](./project.licensing.md) - Details on the MIT License.
+- [Security Best Practices](./project.security.md) - Basic security practices for maintainers.
+- [Standard Files](./project.standard-files.md) - Explanation of standard repo files.
+- [Template Repo Guide](./project.template-repo.md) - Best practices for maintaining this template.
+- [Versioning Guide](./project.versioning.md) - Professional release management.

--- a/docs/project.security.md
+++ b/docs/project.security.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [project](./project.md) > Security Best Practices
+
 # Security Best Practices for Maintainers
 
 As an open-source maintainer, you have a responsibility to ensure your

--- a/docs/project.standard-files.md
+++ b/docs/project.standard-files.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [project](./project.md) > Standard Files
+
 # Standard Repository Files
 
 This document explains the purpose of the standard, language-agnostic

--- a/docs/project.template-repo.md
+++ b/docs/project.template-repo.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [project](./project.md) > Template Repo Guide
+
 # Maintaining `base` as a Template Repository
 
 This document is for maintainers of the `base` repository.

--- a/docs/project.versioning.md
+++ b/docs/project.versioning.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [project](./project.md) > Versioning Guide
+
 # Versioning and Release Management
 
 A well-defined versioning and release strategy is crucial for any professional

--- a/docs/publishing.github-pages.md
+++ b/docs/publishing.github-pages.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [publishing](./publishing.md) > GitHub Pages
+
 # GitHub Pages Site
 
 This repository is configured to use [GitHub Pages](https://pages.github.com/)

--- a/docs/publishing.html.md
+++ b/docs/publishing.html.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [publishing](./publishing.md) > Advanced Publishing with HTML
+
 # Advanced Publishing: HTML, Previews, and More
 
 This guide covers the more advanced features of the publishing platform,

--- a/docs/publishing.magic-links.md
+++ b/docs/publishing.magic-links.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [publishing](./publishing.md) > Publishing with Magic Links
+
 # Publishing with Magic Links
 
 "Magic Links" are special URLs that can pre-fill a new file in a GitHub

--- a/docs/publishing.markdown.md
+++ b/docs/publishing.markdown.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [publishing](./publishing.md) > Publishing with Markdown
+
 # Publishing with Markdown
 
 This repository is pre-configured to act as a simple, powerful, and free

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,33 +1,10 @@
+[base](../README.md) > [docs](./README.md) > publishing
+
 # Publishing Your Project
 
-This repository is pre-configured to act as a simple, powerful, and free
-website publishing platform using GitHub Pages.
-There are several ways to create and manage content, from simple to advanced.
+This repository is pre-configured to act as a simple, powerful, and free website publishing platform using GitHub Pages.
 
-This document provides an overview of the different methods you can use.
-
-## Publishing Guides
-
-- **[Publishing with Markdown](./publishing.markdown.md)**
-  - This is the simplest way to get started.
-    If you are new to web development or just want to write and publish with
-    minimal fuss, start here.
-    This guide covers creating pages, formatting text, adding images, and
-    more, all using plain Markdown files.
-
-- **[Advanced Publishing with HTML](./publishing.html.md)**
-  - For those who need more control over their site's layout and appearance,
-    this guide explains how to use raw HTML files, customize your theme's CSS,
-    and work with more advanced Jekyll features.
-    It also covers the limitations of the platform.
-
-- **[Publishing with Magic Links](./publishing.magic-links.md)**
-  - This guide explains a powerful feature for community-driven sites.
-    Learn how to create special URLs that can pre-fill a new file in your
-    repository with template content, making it easy for users to contribute
-    structured data like bug reports, testimonials, or blog posts.
-
-- **[GitHub Pages](./publishing.github-pages.md)**
-  - This document provides more detail on how the underlying GitHub Pages
-    service works to automatically build and deploy your site whenever you
-    push a change.
+- [Publishing with Markdown](./publishing.markdown.md) - The simplest way to get started.
+- [Advanced Publishing with HTML](./publishing.html.md) - For those who need more control over their site's layout and appearance.
+- [Publishing with Magic Links](./publishing.magic-links.md) - A powerful feature for community-driven sites.
+- [GitHub Pages](./publishing.github-pages.md) - More detail on how the underlying GitHub Pages service works.

--- a/docs/updating.adding-base-to-existing-repo.md
+++ b/docs/updating.adding-base-to-existing-repo.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [updating](./updating.md) > Adding base to an Existing Repo
+
 # Merging `base` Into an Existing Repository
 
 This guide explains how to merge the `attogram/base` repository into your

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1,0 +1,8 @@
+[base](../README.md) > [docs](./README.md) > updating
+
+# Updating
+
+This section contains documentation about updating the repository.
+
+- [Adding `base` to an Existing Repo](./updating.adding-base-to-existing-repo.md) - How to merge `base` into a project that was not created from the template.
+- [Syncing When `base` is Updated](./updating.syncing-your-repo-when-base-is-updated.md) - How to get the latest changes from `base` after you have already merged it.

--- a/docs/updating.syncing-your-repo-when-base-is-updated.md
+++ b/docs/updating.syncing-your-repo-when-base-is-updated.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [updating](./updating.md) > Syncing When base is Updated
+
 # Syncing Your Repo When `base` is Updated
 
 This guide explains how to sync your repository with the latest changes from the

--- a/docs/workflows.ci.md
+++ b/docs/workflows.ci.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [workflows](./workflows.md) > CI Workflow
+
 # CI Workflow
 
 The CI (Continuous Integration) workflow is defined in `.github/workflows/ci.yml`.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,19 +1,12 @@
+[base](../README.md) > [docs](./README.md) > workflows
+
 # CI/CD Workflows
 
 This repository includes several GitHub Actions workflows to automate various tasks. Each workflow is defined in a `.yml` file in the `.github/workflows` directory.
 
-Below is an overview of the available workflows. For more detailed information about a specific workflow, please refer to its dedicated documentation page.
-
-## Workflow Index
-
-- [**CI Workflow**](./workflows.ci.md) (`ci.yml`)
-- Ensures code quality by running linting checks on every push and pull request to the `main` branch.
-
-- [**GitHub Pages Deployment**](./workflows.pages.md) (`pages.yml`)
-- Builds and deploys the repository's content as a GitHub Pages website.
-
-- [**Prettier Workflow**](./workflows.prettier.md) (`prettier.yml`)
-- Automatically formats the code in the repository using Prettier and commits the changes.
-
-- [**Release on Tag**](./workflows.release-on-tag.md) (`release-on-tag.yml`)
-- Automates the creation of GitHub Releases when a new version tag is pushed.
+- [**CI Workflow**](./workflows.ci.md) (`ci.yml`) - Ensures code quality by running linting checks on every push and pull request to the `main` branch.
+- [**GitHub Pages Deployment**](./workflows.pages.md) (`pages.yml`) - Builds and deploys the repository's content as a GitHub Pages website.
+- [**Prettier Workflow**](./workflows.prettier.md) (`prettier.yml`) - Automatically formats the code in the repository using Prettier and commits the changes.
+- [**Release on Tag**](./workflows.release-on-tag.md) (`release-on-tag.yml`) - Automates the creation of GitHub Releases when a new version tag is pushed.
+- [**Secrets Management**](./workflows.secrets-management.md) - Best practices for managing secrets in GitHub Actions.
+- [**Workflow Scheduling**](./workflows.scheduling.md) - Automating recurring tasks with cron.

--- a/docs/workflows.pages.md
+++ b/docs/workflows.pages.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [workflows](./workflows.md) > GitHub Pages Deployment
+
 # GitHub Pages Deployment Workflow
 
 The GitHub Pages deployment workflow is defined in `.github/workflows/pages.yml`. Its purpose is to build and deploy the repository's content as a GitHub Pages website.

--- a/docs/workflows.prettier.md
+++ b/docs/workflows.prettier.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [workflows](./workflows.md) > Prettier Workflow
+
 # Prettier Workflow
 
 The Prettier workflow, defined in `.github/workflows/prettier.yml`, automates code formatting for the entire repository.

--- a/docs/workflows.release-on-tag.md
+++ b/docs/workflows.release-on-tag.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [workflows](./workflows.md) > Release on Tag
+
 # Release on Tag Workflow
 
 The "Create Release" workflow, defined in `.github/workflows/release-on-tag.yml`, automates the process of creating a new GitHub release whenever a new tag is pushed to the repository.

--- a/docs/workflows.scheduling.md
+++ b/docs/workflows.scheduling.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [workflows](./workflows.md) > Workflow Scheduling
+
 # Scheduling Workflows with Cron
 
 GitHub Actions allows you to automate tasks on a schedule, similar to the

--- a/docs/workflows.secrets-management.md
+++ b/docs/workflows.secrets-management.md
@@ -1,3 +1,5 @@
+[base](../../README.md) > [docs](../README.md) > [workflows](./workflows.md) > Secrets Management
+
 # Secrets Management in GitHub Actions
 
 Properly managing secrets like API keys, access tokens, and other credentials


### PR DESCRIPTION
- Implements a dual-TOC documentation structure with a master `docs/README.md` and scoped `docs/<namespace>.md` files.
- Reorders the namespaces in the master TOC to a more logical, user-centric flow.
- Adds clickable breadcrumb navigation to the top of every documentation file.
- Establishes an `in-dev` namespace for work-in-progress documents, which are excluded from the TOCs.
- Updates `AGENTS.md` with all new documentation rules and conventions.

<!--
Thank you for your contribution!

Please provide a clear description of the change and the problem it solves.
If it fixes an open issue, please link to the issue.
-->

### Description

### Related Issue

### Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document.
- [ ] My code follows the style guidelines of this project.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests passed.
